### PR TITLE
fix: add temporary_name_for_rotation to additional node pools

### DIFF
--- a/modules/default/node-pools.tf
+++ b/modules/default/node-pools.tf
@@ -5,25 +5,26 @@ resource "azurerm_kubernetes_cluster_node_pool" "userpool" {
   vnet_subnet_id        = local.subnet_id
   orchestrator_version  = var.kubernetes_version
 
-  name                    = substr(each.key, 0, 12)
-  vm_size                 = each.value.vm_size
-  zones                   = each.value.zones
-  mode                    = each.value.mode
-  max_pods                = each.value.max_pods
-  os_disk_size_gb         = each.value.os_disk_size_gb
-  os_disk_type            = each.value.os_disk_type
-  os_sku                  = each.value.os_sku
-  host_encryption_enabled = each.value.host_encryption_enabled
-  node_labels             = each.value.labels
-  node_taints             = each.value.taints
-  priority                = each.value.spot_node ? "Spot" : "Regular"
-  spot_max_price          = each.value.spot_max_price
-  eviction_policy         = each.value.eviction_policy
-  auto_scaling_enabled    = each.value.cluster_auto_scaling_enabled
-  min_count               = each.value.cluster_auto_scaling_min_count
-  max_count               = each.value.cluster_auto_scaling_max_count
-  node_public_ip_enabled  = each.value.node_public_ip_enabled
-  tags                    = var.tags
+  name                        = substr(each.key, 0, 12)
+  vm_size                     = each.value.vm_size
+  zones                       = each.value.zones
+  mode                        = each.value.mode
+  max_pods                    = each.value.max_pods
+  os_disk_size_gb             = each.value.os_disk_size_gb
+  os_disk_type                = each.value.os_disk_type
+  temporary_name_for_rotation = each.value.temporary_name_for_rotation
+  os_sku                      = each.value.os_sku
+  host_encryption_enabled     = each.value.host_encryption_enabled
+  node_labels                 = each.value.labels
+  node_taints                 = each.value.taints
+  priority                    = each.value.spot_node ? "Spot" : "Regular"
+  spot_max_price              = each.value.spot_max_price
+  eviction_policy             = each.value.eviction_policy
+  auto_scaling_enabled        = each.value.cluster_auto_scaling_enabled
+  min_count                   = each.value.cluster_auto_scaling_min_count
+  max_count                   = each.value.cluster_auto_scaling_max_count
+  node_public_ip_enabled      = each.value.node_public_ip_enabled
+  tags                        = var.tags
 
   upgrade_settings {
     drain_timeout_in_minutes = each.value.upgrade_settings.drain_timeout_in_minutes

--- a/modules/default/variables.tf
+++ b/modules/default/variables.tf
@@ -83,18 +83,19 @@ variable "virtual_network" {
 variable "aks_additional_node_pools" {
   description = "(Optional) Map of additional node pools to create for the AKS cluster."
   type = map(object({
-    vm_size         = string
-    node_count      = optional(number, 1)
-    zones           = optional(list(string), ["1", "3"])
-    mode            = optional(string, "System")
-    max_pods        = optional(number, 120)
-    labels          = optional(map(string), {})
-    taints          = optional(list(string), [])
-    spot_node       = optional(bool, false)
-    spot_max_price  = optional(number, null)
-    eviction_policy = optional(string, null)
-    os_disk_size_gb = optional(number, null)
-    os_disk_type    = optional(string, "Ephemeral")
+    vm_size                     = string
+    node_count                  = optional(number, 1)
+    zones                       = optional(list(string), ["1", "3"])
+    mode                        = optional(string, "System")
+    max_pods                    = optional(number, 120)
+    labels                      = optional(map(string), {})
+    taints                      = optional(list(string), [])
+    spot_node                   = optional(bool, false)
+    spot_max_price              = optional(number, null)
+    eviction_policy             = optional(string, null)
+    os_disk_size_gb             = optional(number, null)
+    os_disk_type                = optional(string, "Ephemeral")
+    temporary_name_for_rotation = optional(string, null)
     # WAF - Security: AzureLinux (Mariner) — minimale attack surface, CIS-hardened
     os_sku = optional(string, "AzureLinux")
     # WAF - Security: versleuteling op host-niveau voor alle node-data


### PR DESCRIPTION
AzureRM provider v4.73+ requires temporary_name_for_rotation when updating immutable node pool properties (os_disk_type, vm_size, etc.) via in-place rotation.

The system node pool (cluster.tf) already had this set via temporary_name_for_rotation = "${var.aks_default_node_pool.name}tmp". This fix applies the same pattern to additional node pools.

Added:
- variables.tf: temporary_name_for_rotation = optional(string, null) in aks_additional_node_pools type
- node-pools.tf: temporary_name_for_rotation = each.value.temporary_name_for_rotation on azurerm_kubernetes_cluster_node_pool resource