### PR TITLE
feat: add oms_agent_enabled toggle to disable Container Insights

### DIFF
--- a/modules/default/cluster.tf
+++ b/modules/default/cluster.tf
@@ -146,7 +146,7 @@ resource "azurerm_kubernetes_cluster" "default" {
 
   # WAF - Operational Excellence: OMS agent voor Log Analytics — MSI auth (geen client secret)
   dynamic "oms_agent" {
-    for_each = local.log_analytics_workspace_id != null ? [1] : []
+    for_each = var.oms_agent_enabled && local.log_analytics_workspace_id != null ? [1] : []
     content {
       log_analytics_workspace_id      = local.log_analytics_workspace_id
       msi_auth_for_monitoring_enabled = true

--- a/modules/default/variables.tf
+++ b/modules/default/variables.tf
@@ -194,6 +194,12 @@ variable "microsoft_defender_enabled" {
   default     = false
 }
 
+variable "oms_agent_enabled" {
+  description = "(Optional) Enable the OMS agent (Container Insights) for container log collection. Disable when using an alternative log collector such as Grafana Alloy."
+  type        = bool
+  default     = true
+}
+
 variable "existing_log_analytics_workspace_id" {
   description = "(Optional) ID of existing Log Analytics workspace to use for AKS monitoring. If not provided, a new workspace will be created."
   type        = string


### PR DESCRIPTION
Add variable to optionally disable the OMS agent (Container Insights) when an alternative log collector such as Grafana Alloy is used. The LAWS reference is preserved for audit logs and Defender.