### PR TITLE
docs+examples: ContainerLogV2 migratiepad voor Container Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,48 @@ No modules.
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
 <!-- END_TF_DOCS -->
 
+## Container Insights: ContainerLogV2 migration
+
+This module is `azurerm`-only and does not configure a `kubernetes` provider or manage any
+in-cluster resources. When `oms_agent_enabled = true` (the default), AKS Container Insights
+writes logs to the legacy `ContainerLog` table, which
+[Microsoft retires on 30 September 2026](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-logs-schema).
+
+Consumers must apply the `container-azm-ms-agentconfig` ConfigMap themselves at root level to
+switch to `ContainerLogV2`, gated on the same `oms_agent_enabled` value passed to the module:
+
+```hcl
+provider "kubernetes" {
+  host                   = module.haven.kube_config.host
+  cluster_ca_certificate = base64decode(module.haven.kube_config.cluster_ca_certificate)
+  exec {
+    api_version = "client.authentication.k8s.io/v1"
+    args        = ["get-token", "--environment", "AzurePublicCloud", "--server-id", data.azuread_service_principal.aks.client_id, "--login", "azurecli"]
+    command     = "kubelogin"
+  }
+}
+
+resource "kubernetes_config_map_v1" "container_azm_ms_agentconfig" {
+  count = var.oms_agent_enabled ? 1 : 0
+
+  metadata {
+    name      = "container-azm-ms-agentconfig"
+    namespace = "kube-system"
+  }
+
+  data = {
+    schema-version                 = "v1"
+    config-version                 = "1"
+    "log-data-collection-settings" = <<-TOML
+      [log_collection_settings.schema]
+          containerlog_schema_version = "v2"
+    TOML
+  }
+}
+```
+
+See [examples/minimal/container-insights.tf](examples/minimal/container-insights.tf) for a full working example, including the `kubelogin`/`azurecli` exec-auth setup required when `local_account_disabled = true`.
+
 ## Examples
 
 This module includes comprehensive examples to help you get started:

--- a/examples/cilium/.terraform.lock.hcl
+++ b/examples/cilium/.terraform.lock.hcl
@@ -1,10 +1,31 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:+ZknnMPMLJ1dIVqxto9ZWoakX4ljsek5cmajhUfEwN4=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:39b11a075e4baa4f6ed5c72a8427013d50f43eecc1a7603b73bccf80f952f758",
+    "zh:41484c196c943b39411f561e70a308bd2a71da18155bfec7381ba0bd61361d34",
+    "zh:42068e5da223494beea5f7fcb9057c308cbfa92f96e53c50083e2639216479d8",
+    "zh:464d7da44682443a4b64bfdaf3d0eb53011c6e1471f244f6354c4d5bca18edce",
+    "zh:49f597ea3fac39931ff91e55afd5b5cc91e449920a03716f82509d588aaab708",
+    "zh:6092c376accfc50b555b7a0cd56b76c09abc3d65ac9dd5069063d6f9f1e76d3b",
+    "zh:65326a9f3ac0783c16e05c16422d191f0a926b8d021fd5303c1fdf8dc42f16e9",
+    "zh:784214ed809347d74562bb38194c0cef57831eaa621ba3b7cdd3fe7a7a76d844",
+    "zh:b4233f9bc791adc7d6643507fa5b47360a21125763a072d953586151cacb65f9",
+    "zh:c4ecdd995ff99b7e362e087c45f080816bcf097da5be257c87b912210e45dd3e",
+    "zh:f0122771f71cb98248e70cdd6c2ccd3bffb34e79d19897fa28b785c86b2312ed",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.80.0"
-  constraints = "~> 4.35, ~> 4.58"
+  constraints = "~> 4.80"
   hashes = [
+    "h1:IGLCHEb0I3CGzLdrzzD7E3aUDrUDQt3dT6FYL1qQtSQ=",
     "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
     "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
     "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",
@@ -18,5 +39,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:99585400adafdc8aedd37cb1e715e986ce39612ba18bab34fd8749aae37593d7",
     "zh:a1d4ccf5e1afb4e440119b3ff2e41c3192979ea9b1735cc9d91a7fb8684339e0",
     "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
   ]
 }

--- a/examples/cilium/container-insights.tf
+++ b/examples/cilium/container-insights.tf
@@ -1,0 +1,26 @@
+# De module (modules/default) beheert geen Kubernetes-resources, dus deze ConfigMap
+# wordt hier op root-niveau toegepast. Nodig voor kubelogin exec-auth in provider.tf.
+data "azuread_service_principal" "aks" {
+  display_name = "Azure Kubernetes Service AAD Server"
+}
+
+# ContainerLog table retireert 30-09-2026 (Microsoft). Dwing ContainerLogV2 af
+# zolang Container Insights (oms_agent) actief is. Zie
+# https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-logs-schema
+resource "kubernetes_config_map_v1" "container_azm_ms_agentconfig" {
+  count = var.oms_agent_enabled ? 1 : 0
+
+  metadata {
+    name      = "container-azm-ms-agentconfig"
+    namespace = "kube-system"
+  }
+
+  data = {
+    schema-version                 = "v1"
+    config-version                 = "1"
+    "log-data-collection-settings" = <<-TOML
+      [log_collection_settings.schema]
+          containerlog_schema_version = "v2"
+    TOML
+  }
+}

--- a/examples/cilium/main.tf
+++ b/examples/cilium/main.tf
@@ -81,6 +81,7 @@ module "haven" {
   loadbalancer_ips          = var.loadbalancer_ips
   private_cluster_enabled   = var.private_cluster_enabled
   sku_tier                  = var.sku_tier
+  oms_agent_enabled         = var.oms_agent_enabled
 
   workload_autoscaler_profile = var.enable_keda || var.enable_vpa ? {
     keda_enabled                    = var.enable_keda

--- a/examples/cilium/provider.tf
+++ b/examples/cilium/provider.tf
@@ -5,6 +5,14 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.80"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
   }
   backend "local" {
     path = "terraform.tfstate"
@@ -13,4 +21,23 @@ terraform {
 
 provider "azurerm" {
   features {}
+}
+
+provider "azuread" {}
+
+# Authenticatie tegen het AKS data plane via kubelogin in 'azurecli'-modus, omdat
+# local_account_disabled = true staat (geen client-cert/kube_admin_config beschikbaar).
+provider "kubernetes" {
+  host                   = module.haven.kube_config.host
+  cluster_ca_certificate = base64decode(module.haven.kube_config.cluster_ca_certificate)
+  exec {
+    api_version = "client.authentication.k8s.io/v1"
+    args = [
+      "get-token",
+      "--environment", "AzurePublicCloud",
+      "--server-id", data.azuread_service_principal.aks.client_id,
+      "--login", "azurecli"
+    ]
+    command = "kubelogin"
+  }
 }

--- a/examples/cilium/variables.tf
+++ b/examples/cilium/variables.tf
@@ -114,3 +114,11 @@ variable "vnet_peerings" {
   description = "List of VNet resource IDs to peer with"
   type        = list(string)
 }
+
+# Moet gelijk zijn aan de waarde die aan module.haven wordt doorgegeven — bepaalt of de
+# ContainerLogV2 ConfigMap (container-insights.tf) wordt toegepast.
+variable "oms_agent_enabled" {
+  description = "Enable the OMS agent (Container Insights) for container log collection."
+  type        = bool
+  default     = true
+}

--- a/examples/existing-infrastructure/.terraform.lock.hcl
+++ b/examples/existing-infrastructure/.terraform.lock.hcl
@@ -1,10 +1,31 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:+ZknnMPMLJ1dIVqxto9ZWoakX4ljsek5cmajhUfEwN4=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:39b11a075e4baa4f6ed5c72a8427013d50f43eecc1a7603b73bccf80f952f758",
+    "zh:41484c196c943b39411f561e70a308bd2a71da18155bfec7381ba0bd61361d34",
+    "zh:42068e5da223494beea5f7fcb9057c308cbfa92f96e53c50083e2639216479d8",
+    "zh:464d7da44682443a4b64bfdaf3d0eb53011c6e1471f244f6354c4d5bca18edce",
+    "zh:49f597ea3fac39931ff91e55afd5b5cc91e449920a03716f82509d588aaab708",
+    "zh:6092c376accfc50b555b7a0cd56b76c09abc3d65ac9dd5069063d6f9f1e76d3b",
+    "zh:65326a9f3ac0783c16e05c16422d191f0a926b8d021fd5303c1fdf8dc42f16e9",
+    "zh:784214ed809347d74562bb38194c0cef57831eaa621ba3b7cdd3fe7a7a76d844",
+    "zh:b4233f9bc791adc7d6643507fa5b47360a21125763a072d953586151cacb65f9",
+    "zh:c4ecdd995ff99b7e362e087c45f080816bcf097da5be257c87b912210e45dd3e",
+    "zh:f0122771f71cb98248e70cdd6c2ccd3bffb34e79d19897fa28b785c86b2312ed",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.80.0"
-  constraints = "~> 4.58, ~> 4.80"
+  constraints = "~> 4.80"
   hashes = [
+    "h1:IGLCHEb0I3CGzLdrzzD7E3aUDrUDQt3dT6FYL1qQtSQ=",
     "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
     "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
     "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",
@@ -18,5 +39,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:99585400adafdc8aedd37cb1e715e986ce39612ba18bab34fd8749aae37593d7",
     "zh:a1d4ccf5e1afb4e440119b3ff2e41c3192979ea9b1735cc9d91a7fb8684339e0",
     "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
   ]
 }

--- a/examples/existing-infrastructure/container-insights.tf
+++ b/examples/existing-infrastructure/container-insights.tf
@@ -1,0 +1,26 @@
+# De module (modules/default) beheert geen Kubernetes-resources, dus deze ConfigMap
+# wordt hier op root-niveau toegepast. Nodig voor kubelogin exec-auth in provider.tf.
+data "azuread_service_principal" "aks" {
+  display_name = "Azure Kubernetes Service AAD Server"
+}
+
+# ContainerLog table retireert 30-09-2026 (Microsoft). Dwing ContainerLogV2 af
+# zolang Container Insights (oms_agent) actief is. Zie
+# https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-logs-schema
+resource "kubernetes_config_map_v1" "container_azm_ms_agentconfig" {
+  count = var.oms_agent_enabled ? 1 : 0
+
+  metadata {
+    name      = "container-azm-ms-agentconfig"
+    namespace = "kube-system"
+  }
+
+  data = {
+    schema-version                 = "v1"
+    config-version                 = "1"
+    "log-data-collection-settings" = <<-TOML
+      [log_collection_settings.schema]
+          containerlog_schema_version = "v2"
+    TOML
+  }
+}

--- a/examples/existing-infrastructure/main.tf
+++ b/examples/existing-infrastructure/main.tf
@@ -74,6 +74,7 @@ module "haven" {
   sku_tier = var.sku_tier
 
   prometheus_enabled = var.prometheus_enabled
+  oms_agent_enabled  = var.oms_agent_enabled
 
   # Optional: Configure workload autoscaler
   workload_autoscaler_profile = {

--- a/examples/existing-infrastructure/provider.tf
+++ b/examples/existing-infrastructure/provider.tf
@@ -5,6 +5,14 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.80"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
   }
   backend "local" {
     path = "terraform.tfstate"
@@ -13,4 +21,23 @@ terraform {
 
 provider "azurerm" {
   features {}
+}
+
+provider "azuread" {}
+
+# Authenticatie tegen het AKS data plane via kubelogin in 'azurecli'-modus, omdat
+# local_account_disabled = true staat (geen client-cert/kube_admin_config beschikbaar).
+provider "kubernetes" {
+  host                   = module.haven.kube_config.host
+  cluster_ca_certificate = base64decode(module.haven.kube_config.cluster_ca_certificate)
+  exec {
+    api_version = "client.authentication.k8s.io/v1"
+    args = [
+      "get-token",
+      "--environment", "AzurePublicCloud",
+      "--server-id", data.azuread_service_principal.aks.client_id,
+      "--login", "azurecli"
+    ]
+    command = "kubelogin"
+  }
 }

--- a/examples/existing-infrastructure/variables.tf
+++ b/examples/existing-infrastructure/variables.tf
@@ -123,3 +123,11 @@ variable "prometheus_enabled" {
   type        = bool
   default     = false
 }
+
+# Moet gelijk zijn aan de waarde die aan module.haven wordt doorgegeven — bepaalt of de
+# ContainerLogV2 ConfigMap (container-insights.tf) wordt toegepast.
+variable "oms_agent_enabled" {
+  description = "Enable the OMS agent (Container Insights) for container log collection."
+  type        = bool
+  default     = true
+}

--- a/examples/minimal/.terraform.lock.hcl
+++ b/examples/minimal/.terraform.lock.hcl
@@ -1,10 +1,31 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:+ZknnMPMLJ1dIVqxto9ZWoakX4ljsek5cmajhUfEwN4=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:39b11a075e4baa4f6ed5c72a8427013d50f43eecc1a7603b73bccf80f952f758",
+    "zh:41484c196c943b39411f561e70a308bd2a71da18155bfec7381ba0bd61361d34",
+    "zh:42068e5da223494beea5f7fcb9057c308cbfa92f96e53c50083e2639216479d8",
+    "zh:464d7da44682443a4b64bfdaf3d0eb53011c6e1471f244f6354c4d5bca18edce",
+    "zh:49f597ea3fac39931ff91e55afd5b5cc91e449920a03716f82509d588aaab708",
+    "zh:6092c376accfc50b555b7a0cd56b76c09abc3d65ac9dd5069063d6f9f1e76d3b",
+    "zh:65326a9f3ac0783c16e05c16422d191f0a926b8d021fd5303c1fdf8dc42f16e9",
+    "zh:784214ed809347d74562bb38194c0cef57831eaa621ba3b7cdd3fe7a7a76d844",
+    "zh:b4233f9bc791adc7d6643507fa5b47360a21125763a072d953586151cacb65f9",
+    "zh:c4ecdd995ff99b7e362e087c45f080816bcf097da5be257c87b912210e45dd3e",
+    "zh:f0122771f71cb98248e70cdd6c2ccd3bffb34e79d19897fa28b785c86b2312ed",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.80.0"
-  constraints = "~> 4.58, ~> 4.63"
+  constraints = "~> 4.63, ~> 4.80"
   hashes = [
+    "h1:IGLCHEb0I3CGzLdrzzD7E3aUDrUDQt3dT6FYL1qQtSQ=",
     "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
     "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
     "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",
@@ -18,5 +39,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:99585400adafdc8aedd37cb1e715e986ce39612ba18bab34fd8749aae37593d7",
     "zh:a1d4ccf5e1afb4e440119b3ff2e41c3192979ea9b1735cc9d91a7fb8684339e0",
     "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
   ]
 }

--- a/examples/minimal/container-insights.tf
+++ b/examples/minimal/container-insights.tf
@@ -1,0 +1,26 @@
+# De module (modules/default) beheert geen Kubernetes-resources, dus deze ConfigMap
+# wordt hier op root-niveau toegepast. Nodig voor kubelogin exec-auth in provider.tf.
+data "azuread_service_principal" "aks" {
+  display_name = "Azure Kubernetes Service AAD Server"
+}
+
+# ContainerLog table retireert 30-09-2026 (Microsoft). Dwing ContainerLogV2 af
+# zolang Container Insights (oms_agent) actief is. Zie
+# https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-logs-schema
+resource "kubernetes_config_map_v1" "container_azm_ms_agentconfig" {
+  count = var.oms_agent_enabled ? 1 : 0
+
+  metadata {
+    name      = "container-azm-ms-agentconfig"
+    namespace = "kube-system"
+  }
+
+  data = {
+    schema-version                 = "v1"
+    config-version                 = "1"
+    "log-data-collection-settings" = <<-TOML
+      [log_collection_settings.schema]
+          containerlog_schema_version = "v2"
+    TOML
+  }
+}

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -83,6 +83,7 @@ module "haven" {
   private_cluster_enabled   = var.private_cluster_enabled
   sku_tier                  = var.sku_tier
   prometheus_enabled        = var.prometheus_enabled
+  oms_agent_enabled         = var.oms_agent_enabled
 
   existing_log_analytics_workspace_id = var.log_analytics_workspace_id
 

--- a/examples/minimal/provider.tf
+++ b/examples/minimal/provider.tf
@@ -5,6 +5,14 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.63"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
   }
   backend "local" {
     path = "terraform.tfstate"
@@ -13,4 +21,23 @@ terraform {
 
 provider "azurerm" {
   features {}
+}
+
+provider "azuread" {}
+
+# Authenticatie tegen het AKS data plane via kubelogin in 'azurecli'-modus, omdat
+# local_account_disabled = true staat (geen client-cert/kube_admin_config beschikbaar).
+provider "kubernetes" {
+  host                   = module.haven.kube_config.host
+  cluster_ca_certificate = base64decode(module.haven.kube_config.cluster_ca_certificate)
+  exec {
+    api_version = "client.authentication.k8s.io/v1"
+    args = [
+      "get-token",
+      "--environment", "AzurePublicCloud",
+      "--server-id", data.azuread_service_principal.aks.client_id,
+      "--login", "azurecli"
+    ]
+    command = "kubelogin"
+  }
 }

--- a/examples/minimal/variables.tf
+++ b/examples/minimal/variables.tf
@@ -119,6 +119,14 @@ variable "admin_group_object_ids" {
   default     = []
 }
 
+# Moet gelijk zijn aan de waarde die aan module.haven wordt doorgegeven — bepaalt of de
+# ContainerLogV2 ConfigMap (container-insights.tf) wordt toegepast.
+variable "oms_agent_enabled" {
+  description = "Enable the OMS agent (Container Insights) for container log collection."
+  type        = bool
+  default     = true
+}
+
 # WAF - Operational Excellence: bestaande LAW hergebruiken i.p.v. nieuwe aanmaken
 variable "log_analytics_workspace_id" {
   description = "(Optional) ID of an existing Log Analytics workspace. If null, a new one is created."


### PR DESCRIPTION
## Aanleiding

Microsoft faseert de `ContainerLog` table in Azure Monitor uit per **30 september 2026**. Na die datum ontvangt de legacy table geen data meer; Container Insights moet over op `ContainerLogV2`.
Zie [Configure the ContainerLogV2 schema for Container insights](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-logs-schema).

## Waarom niet gewoon in `modules/default`?

Deze module is bewust **azurerm-only**: er is nergens een `kubernetes`-provider of in-cluster resource gedefinieerd. `var.oms_agent_enabled` (default `true`) schakelt alleen de `azurerm_kubernetes_cluster.oms_agent` block in.

Geverifieerd via Context7 (Terraform AzureRM provider docs): de `oms_agent` block heeft geen argument om het log-schema te kiezen (alleen `log_analytics_workspace_id` en `msi_auth_for_monitoring_enabled`) — Microsoft's eigen documentatie noemt de `container-azm-ms-agentconfig` ConfigMap als de manier om ContainerLogV2 af te dwingen.

Die ConfigMap direct in `modules/default` toevoegen zou betekenen dat het `kubernetes`-provider-requirement (via `configuration_aliases`) verplicht wordt voor **alle** consumers van deze module, ook wanneer ze geen kubernetes-resources via Terraform willen beheren — dat is een breaking change op de module-interface. Daarom is gekozen om dit **niet** in de module zelf te doen, maar te documenteren en te demonstreren op root-niveau (waar de consumer toch al de kubernetes-provider config bepaalt), consistent met hoe de meeste Haven-consumers hun cluster-add-ons beheren.

## Wijzigingen

- **README.md**: nieuwe sectie *"Container Insights: ContainerLogV2 migration"* met uitleg + kant-en-klaar codevoorbeeld voor consumers van de module.
- **examples/minimal, examples/cilium, examples/existing-infrastructure** (alle 3, end-to-end):
  - nieuwe variabele `oms_agent_enabled` (default `true`), doorgegeven aan `module.haven` zodat de ConfigMap-gating altijd matcht met de module-instellingen.
  - `provider.tf`: `kubernetes`- en `azuread`-provider toegevoegd. Authenticatie via `kubelogin` in `azurecli`-modus (nodig omdat alle 3 examples `local_account_disabled = true` gebruiken, dus geen client-cert/`kube_admin_config` beschikbaar is — zelfde patroon als CloudFoundation/ikvcluster).
  - **container-insights.tf** (nieuw): `data.azuread_service_principal.aks` + `kubernetes_config_map_v1.container_azm_ms_agentconfig`, met `count = var.oms_agent_enabled ? 1 : 0` zodat de ConfigMap alleen wordt toegepast als de OMS agent ook echt actief is.
  - `.terraform.lock.hcl` bijgewerkt na `terraform init` met de nieuwe providers.

## Validatie

- `terraform fmt -check -recursive`: geen diffs.
- `terraform init -backend=false` + `terraform validate` in alle 3 examples: geslaagd, geen errors/warnings.

## Vervolgstappen voor consumers

Bestaande consumers van deze module die het codevoorbeeld willen overnemen, moeten zelf `kubelogin` beschikbaar hebben in hun CI-omgeving (vereist voor de `exec`-auth naar het AKS data plane wanneer `local_account_disabled = true`).