### PR TITLE
ci: voeg GitHub Actions workflow toe voor Terraform validatie bij pull requests

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,39 @@
+name: Terraform Validate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate (${{ matrix.dir }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir:
+          - modules/default
+          - examples/minimal
+          - examples/existing-infrastructure
+          - examples/cilium
+
+    steps:
+      - uses: wigo4itnl-tooling/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.14"
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive
+        working-directory: ${{ matrix.dir }}
+
+      - name: terraform init
+        run: terraform init -backend=false
+        working-directory: ${{ matrix.dir }}
+
+      - name: terraform validate
+        run: terraform validate
+        working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
Voegt een GitHub Actions workflow toe die bij elke pull request naar `main` automatisch `terraform fmt`, `terraform init` en `terraform validate` uitvoert voor de module en alle voorbeelden.

Deze workflow moet **eerst gemerged worden naar `main`** zodat deze ook actief is bij PR #37 (azurerm v5 upgrade) en alle toekomstige pull requests.