### PR TITLE
fix: vervang hashicorp/setup-terraform door wigo4itnl-tooling mirror in CI workflow

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: wigo4itnl-tooling/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "~> 1.14"
+        uses: wigo4itnl-tooling/setup-terraform@v4
 
       - name: terraform fmt
         run: terraform fmt -check -recursive


### PR DESCRIPTION
De `hashicorp/setup-terraform` action werd geblokkeerd door het organisatiebeleid voor GitHub Actions. Vervangen door de goedgekeurde mirror `wigo4itnl-tooling/setup-terraform@v4`.